### PR TITLE
cloud-init RHEL support for dual stack multiple addresses with active interface detection

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -69,7 +69,7 @@ class Distro(object):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def _write_network(self, settings):
+    def _write_network(self, settings, json_config=False):
         # In the future use the http://fedorahosted.org/netcf/
         # to write this blob out in a distro format
         raise NotImplementedError()
@@ -117,9 +117,9 @@ class Distro(object):
         return _get_package_mirror_info(availability_zone=availability_zone,
                                         mirror_info=arch_info)
 
-    def apply_network(self, settings, bring_up=True):
+    def apply_network(self, settings, bring_up=True, json_config=False):
         # Write it out
-        dev_names = self._write_network(settings)
+        dev_names = self._write_network(settings, json_config)
         # Now try to bring them up
         if bring_up:
             return self._bring_up_interfaces(dev_names)

--- a/cloudinit/distros/arch.py
+++ b/cloudinit/distros/arch.py
@@ -60,7 +60,7 @@ class Distro(distros.Distro):
         self.update_package_sources()
         self.package_command('', pkgs=pkglist)
 
-    def _write_network(self, settings):
+    def _write_network(self, settings, json_config=False):
         entries = net_util.translate_network(settings)
         LOG.debug("Translated ubuntu style network settings %s into %s",
                   settings, entries)

--- a/cloudinit/distros/debian.py
+++ b/cloudinit/distros/debian.py
@@ -72,7 +72,7 @@ class Distro(distros.Distro):
         self.update_package_sources()
         self.package_command('install', pkgs=pkglist)
 
-    def _write_network(self, settings):
+    def _write_network(self, settings, json_config=False):
         util.write_file(self.network_conf_fn, settings)
         return ['all']
 

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -268,7 +268,7 @@ class Distro(distros.Distro):
             keys = set(kwargs['ssh_authorized_keys']) or []
             ssh_util.setup_user_keys(keys, name, options=None)
 
-    def _write_network(self, settings):
+    def _write_network(self, settings, json_config=False):
         entries = net_util.translate_network(settings)
         nameservers = []
         searchdomains = []

--- a/cloudinit/distros/gentoo.py
+++ b/cloudinit/distros/gentoo.py
@@ -59,7 +59,7 @@ class Distro(distros.Distro):
         self.update_package_sources()
         self.package_command('', pkgs=pkglist)
 
-    def _write_network(self, settings):
+    def _write_network(self, settings, json_config=False):
         util.write_file(self.network_conf_fn, settings)
         return ['all']
 

--- a/cloudinit/distros/sles.py
+++ b/cloudinit/distros/sles.py
@@ -53,7 +53,7 @@ class Distro(distros.Distro):
     def install_packages(self, pkglist):
         self.package_command('install', args='-l', pkgs=pkglist)
 
-    def _write_network(self, settings):
+    def _write_network(self, settings, json_config=False):
         # Convert debian settings to ifcfg format
         entries = net_util.translate_network(settings)
         LOG.debug("Translated ubuntu style network settings %s into %s",

--- a/cloudinit/sources/DataSourceConfigDrive.py
+++ b/cloudinit/sources/DataSourceConfigDrive.py
@@ -212,7 +212,8 @@ def on_first_boot(data, distro=None):
     net_conf = data.get("network_config", '')
     if net_conf and distro:
         LOG.debug("Updating network interfaces from config drive")
-        distro.apply_network(net_conf)
+        json_config = data.get("network", False)
+        distro.apply_network(net_conf, json_config=json_config)
     files = data.get('files', {})
     if files:
         LOG.debug("Writing %s injected files", len(files))

--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -219,6 +219,11 @@ class BaseReader(object):
                 # Translator function (applied after loading)
                 util.load_json,
             )
+            files['network'] = (
+                self._path_join("openstack", version, 'net_data.json'),
+                False,
+                util.load_json,
+            )
             files['userdata'] = (
                 self._path_join("openstack", version, 'user_data'),
                 False,
@@ -295,6 +300,9 @@ class BaseReader(object):
             except IOError as e:
                 raise BrokenMetadata("Failed to read network"
                                      " configuration: %s" % (e))
+        if 'network' in results:
+            results['network_config'] = results['network']
+            results['network'] = True
 
         # To openstack, user can specify meta ('nova boot --meta=key=value')
         # and those will appear under metadata['meta'].

--- a/tests/unittests/test_datasource/test_configdrive.py
+++ b/tests/unittests/test_datasource/test_configdrive.py
@@ -46,6 +46,9 @@ EC2_META = {
     'reservation-id': 'r-iru5qm4m',
     'security-groups': ['default']
 }
+OSTACK_NET_DATA = {
+    'lo': {'auto': True, 'ipv6': {}}, 'eth6': {'auto': True, 'address': '192.168.123.26', 'dns-nameservers': ['192.168.123.1'], 'gateway': '192.168.123.1', 'broadcast': '192.168.123.255', 'netmask': '255.255.255.0', 'bootproto': 'static', 'ipv6': {'address': '2001:4998:44:2804::72/120', 'secondaries': ['2001:4998:44:2804::73/120', '2001:4998:44:2804::74/120'], 'dns-nameservers': [], 'gateway': '2001:4998:44:2804::1'}, 'inet6': True}, 'eth6:0': {'auto': True, 'ipv6': {'gateway': None, 'secondaries': [], 'dns-nameservers': [], 'address': None}, 'dns-nameservers': ['192.168.123.1'], 'inet6': False, 'broadcast': '192.168.123.255', 'netmask': '255.255.255.0', 'bootproto': 'static', 'address': '192.168.123.201', 'gateway': '192.168.123.1'}}
+
 USER_DATA = b'#!/bin/sh\necho This is user data\n'
 OSTACK_META = {
     'availability_zone': 'nova',
@@ -70,7 +73,8 @@ CFG_DRIVE_FILES_V2 = {
   'openstack/content/0000': CONTENT_0,
   'openstack/content/0001': CONTENT_1,
   'openstack/latest/meta_data.json': json.dumps(OSTACK_META),
-  'openstack/latest/user_data': USER_DATA}
+  'openstack/latest/user_data': USER_DATA,
+  'openstack/latest/net_data.json': json.dumps(OSTACK_NET_DATA)}
 
 
 class TestConfigDriveDataSource(TestCase):
@@ -320,7 +324,6 @@ class TestConfigDriveDataSource(TestCase):
         myds = cfg_ds_from_dir(self.tmp)
         self.assertEqual(myds.get_public_ssh_keys(),
            [OSTACK_META['public_keys']['mykey']])
-
 
 def cfg_ds_from_dir(seed_d):
     found = ds.read_config_drive(seed_d)

--- a/tests/unittests/test_distros/test_netconfig.py
+++ b/tests/unittests/test_distros/test_netconfig.py
@@ -1,3 +1,4 @@
+import copy
 import os
 
 try:
@@ -45,11 +46,11 @@ iface eth0 inet static
     address 192.168.1.5
     netmask 255.255.255.0
     network 192.168.0.0
-    broadcast 192.168.1.0
+    broadcast 192.168.1.255
     gateway 192.168.1.254
 
 iface eth0 inet6 static
-    address 2607:f0d0:1002:0011::2
+    address 2607:f0d0:1002:0011::2/64
     netmask 64
     gateway 2607:f0d0:1002:0011::1
 
@@ -57,14 +58,17 @@ iface eth1 inet static
     address 192.168.1.6
     netmask 255.255.255.0
     network 192.168.0.0
-    broadcast 192.168.1.0
+    broadcast 192.168.1.255
     gateway 192.168.1.254
 
 iface eth1 inet6 static
-    address 2607:f0d0:1002:0011::3
+    address 2607:f0d0:1002:0011::3/64
     netmask 64
     gateway 2607:f0d0:1002:0011::1
 '''
+
+BASE_NET_CFG_IPV6_JSON = {
+    'lo': {'auto': True, 'ipv6': {}}, 'eth0': {'auto': True, 'address': '192.168.1.5', 'dns-nameservers': [], 'gateway': '192.168.1.254', 'broadcast': '192.168.1.255', 'netmask': '255.255.255.0', 'bootproto': 'static', 'ipv6': {'address': '2607:f0d0:1002:0011::2/64', 'secondaries': [], 'dns-nameservers': [], 'gateway': '2607:f0d0:1002:0011::1'}, 'inet6': True}, 'eth1': {'auto': False, 'ipv6': {'gateway': '2607:f0d0:1002:0011::1', 'secondaries': [], 'dns-nameservers': [], 'address': '2607:f0d0:1002:0011::3/64'}, 'dns-nameservers': [], 'inet6': True, 'broadcast': '192.168.1.255', 'netmask': '255.255.255.0', 'bootproto': 'static', 'address': '192.168.1.6', 'gateway': '192.168.1.254'}}
 
 
 class WriteBuffer(object):
@@ -127,6 +131,7 @@ class TestNetCfgDistro(TestCase):
 
     def test_simple_write_rh(self):
         rh_distro = self._get_distro('rhel')
+        rh_distro._detect_active_device = mock.MagicMock(return_value='eth0')
 
         write_bufs = {}
 
@@ -193,8 +198,9 @@ NETWORKING=yes
             self.assertCfgEquals(expected_buf, str(write_buf))
             self.assertEquals(write_buf.mode, 0o644)
 
-    def test_write_ipv6_rhel(self):
+    def _test_rhel_subif_and_ipv6_json(self, nw_cfg):
         rh_distro = self._get_distro('rhel')
+        rh_distro._detect_active_device = mock.MagicMock(return_value='eth0')
 
         write_bufs = {}
 
@@ -212,8 +218,10 @@ NETWORKING=yes
                 mock.patch.object(util, 'load_file', return_value=''))
             mocks.enter_context(
                 mock.patch.object(os.path, 'isfile', return_value=False))
+            mocks.enter_context(
+                mock.patch.object(os.path, 'isfile', return_value=False))
 
-            rh_distro.apply_network(BASE_NET_CFG_IPV6, False)
+            rh_distro.apply_network(nw_cfg, False, True)
 
             self.assertEquals(len(write_bufs), 4)
             self.assertIn('/etc/sysconfig/network-scripts/ifcfg-lo',
@@ -236,9 +244,121 @@ NETMASK="255.255.255.0"
 IPADDR="192.168.1.5"
 ONBOOT=yes
 GATEWAY="192.168.1.254"
-BROADCAST="192.168.1.0"
+BROADCAST="192.168.1.255"
 IPV6INIT=yes
-IPV6ADDR="2607:f0d0:1002:0011::2"
+IPV6ADDR="2607:f0d0:1002:0011::2/64"
+IPV6_DEFAULTGW="2607:f0d0:1002:0011::1"
+IPV6ADDR_SECONDARIES="2607:f0d0:1002:0011::3/64"
+'''
+            self.assertCfgEquals(expected_buf, str(write_buf))
+            self.assertEquals(write_buf.mode, 0o644)
+            self.assertIn('/etc/sysconfig/network-scripts/ifcfg-eth0:1',
+                          write_bufs)
+            write_buf = write_bufs['/etc/sysconfig/network-scripts/ifcfg-eth0:1']
+            expected_buf = '''
+DEVICE="eth0:1"
+BOOTPROTO="static"
+NETMASK="255.255.255.0"
+IPADDR="192.168.1.6"
+ONBOOT=no
+GATEWAY="192.168.1.254"
+BROADCAST="192.168.1.255"
+'''
+            self.assertCfgEquals(expected_buf, str(write_buf))
+            self.assertEquals(write_buf.mode, 0o644)
+
+            self.assertIn('/etc/sysconfig/network', write_bufs)
+            write_buf = write_bufs['/etc/sysconfig/network']
+            expected_buf = '''
+# Created by cloud-init v. 0.7
+NETWORKING=yes
+NETWORKING_IPV6=yes
+IPV6_AUTOCONF=no
+'''
+            self.assertCfgEquals(expected_buf, str(write_buf))
+            self.assertEquals(write_buf.mode, 0o644)
+
+    def test_rhel_active_interface_replacement(self):
+        subif_ipv6_sec = copy.deepcopy(BASE_NET_CFG_IPV6_JSON)
+        # replace eth0 with eth6, eth1 with eth6:1
+        subif_ipv6_sec['eth6'] = subif_ipv6_sec['eth0']
+        subif_ipv6_sec['eth6:1'] = subif_ipv6_sec['eth1']
+        del subif_ipv6_sec['eth0']
+        del subif_ipv6_sec['eth1']
+        del subif_ipv6_sec['eth6:1']['ipv6']
+        subif_ipv6_sec['eth6:1']['inet6'] = False
+        subif_ipv6_sec['eth6']['ipv6']['secondaries'] = ['2607:f0d0:1002:0011::3/64']
+
+        self._test_rhel_subif_and_ipv6_json(subif_ipv6_sec)
+
+    def test_rhel_subif_and_ipv6_secondary(self):
+        subif_ipv6_sec = copy.deepcopy(BASE_NET_CFG_IPV6_JSON)
+        # replace eth1 with eth0:1, for subif
+        subif_ipv6_sec['eth0:1'] = subif_ipv6_sec['eth1']
+        del subif_ipv6_sec['eth1']
+        del subif_ipv6_sec['eth0:1']['ipv6']
+        subif_ipv6_sec['eth0:1']['inet6'] = False
+
+        # populate ipv6 secondary for eth0
+        subif_ipv6_sec['eth0']['ipv6']['secondaries'] = ['2607:f0d0:1002:0011::3/64']
+
+        self._test_rhel_subif_and_ipv6_json(subif_ipv6_sec)
+
+    def test_write_ipv6_rhel(self):
+        self._test_write_ipv6_rhel(BASE_NET_CFG_IPV6, False)
+
+    def test_write_ipv6_rhel_json(self):
+        self._test_write_ipv6_rhel(BASE_NET_CFG_IPV6_JSON, True)
+
+    def _test_write_ipv6_rhel(self, nw_cfg, is_json=False):
+        rh_distro = self._get_distro('rhel')
+        rh_distro._detect_active_device = mock.MagicMock(return_value='eth0')
+
+        write_bufs = {}
+
+        def replace_write(filename, content, mode=0o644, omode="wb"):
+            buf = WriteBuffer()
+            buf.mode = mode
+            buf.omode = omode
+            buf.write(content)
+            write_bufs[filename] = buf
+
+        with ExitStack() as mocks:
+            mocks.enter_context(
+                mock.patch.object(util, 'write_file', replace_write))
+            mocks.enter_context(
+                mock.patch.object(util, 'load_file', return_value=''))
+            mocks.enter_context(
+                mock.patch.object(os.path, 'isfile', return_value=False))
+            mocks.enter_context(
+                mock.patch.object(os.path, 'isfile', return_value=False))
+
+            rh_distro.apply_network(nw_cfg, False, is_json)
+
+            self.assertEquals(len(write_bufs), 4)
+            self.assertIn('/etc/sysconfig/network-scripts/ifcfg-lo',
+                          write_bufs)
+            write_buf = write_bufs['/etc/sysconfig/network-scripts/ifcfg-lo']
+            expected_buf = '''
+DEVICE="lo"
+ONBOOT=yes
+'''
+            self.assertCfgEquals(expected_buf, str(write_buf))
+            self.assertEquals(write_buf.mode, 0o644)
+
+            self.assertIn('/etc/sysconfig/network-scripts/ifcfg-eth0',
+                          write_bufs)
+            write_buf = write_bufs['/etc/sysconfig/network-scripts/ifcfg-eth0']
+            expected_buf = '''
+DEVICE="eth0"
+BOOTPROTO="static"
+NETMASK="255.255.255.0"
+IPADDR="192.168.1.5"
+ONBOOT=yes
+GATEWAY="192.168.1.254"
+BROADCAST="192.168.1.255"
+IPV6INIT=yes
+IPV6ADDR="2607:f0d0:1002:0011::2/64"
 IPV6_DEFAULTGW="2607:f0d0:1002:0011::1"
 '''
             self.assertCfgEquals(expected_buf, str(write_buf))
@@ -253,9 +373,9 @@ NETMASK="255.255.255.0"
 IPADDR="192.168.1.6"
 ONBOOT=no
 GATEWAY="192.168.1.254"
-BROADCAST="192.168.1.0"
+BROADCAST="192.168.1.255"
 IPV6INIT=yes
-IPV6ADDR="2607:f0d0:1002:0011::3"
+IPV6ADDR="2607:f0d0:1002:0011::3/64"
 IPV6_DEFAULTGW="2607:f0d0:1002:0011::1"
 '''
             self.assertCfgEquals(expected_buf, str(write_buf))


### PR DESCRIPTION
Cloud-init needs to support multiple IP addresses with dual stack. If an instance is allocated with multiple IPv4 addresses from same subnet, it is desirable to have those addresses as sub-interfaces/aliases. Multiple IPv6 addresses from same subnet, should be configured on the same interface, as the protocol supports.

Cloud-Init needs to support multiple IPv6 addresses with correct network mask.

The patch proposes a new model for network configuration - in JSON format, net_data.json.
If the config comes in JSON format, we will use the same
without translation. If net_data.json is present, it will be preferred over the same under 'content/'.
This is to support dual mode, for now.

OpenStack Ironic presents a unique use-case - the cloud-init content mentions
eth0 configuration, whereas the host may have a different active
interface.
To mitigate this, we will use active interface detection in cloud-init.
During the provisioning stage, the host gets configured with the
provisioning network (DHCP). By looking at the deault route, at this stage,
we can figure out the active interface.
Once detected, we need to replace the interface name with the active
interface.

Active interface substitution has to work for sub-interfaces too, in
this case.
